### PR TITLE
将 jvmTest 中的 测试代码移动到 commonTest

### DIFF
--- a/buildSrc/src/main/kotlin/MilkyTypesGenTask.kt
+++ b/buildSrc/src/main/kotlin/MilkyTypesGenTask.kt
@@ -27,8 +27,9 @@ abstract class MilkyTypesGenTask @Inject constructor(
         file.parentFile.mkdirs()
 
         execOperations.exec {
+            val prefix = if (System.getProperty("os.name").contains("Win")) "npx.cmd" else "npx"
             commandLine(
-                "npx", "milkygen", "generate", "kotlin/kotlinx-serialization",
+                prefix, "milkygen", "generate", "kotlin/kotlinx-serialization",
                 "--version", version.get(),
                 "--output", file.absolutePath
             )

--- a/buildSrc/src/main/kotlin/MilkyTypesGenTask.kt
+++ b/buildSrc/src/main/kotlin/MilkyTypesGenTask.kt
@@ -27,9 +27,8 @@ abstract class MilkyTypesGenTask @Inject constructor(
         file.parentFile.mkdirs()
 
         execOperations.exec {
-            val prefix = if (System.getProperty("os.name").contains("Win")) "npx.cmd" else "npx"
             commandLine(
-                prefix, "milkygen", "generate", "kotlin/kotlinx-serialization",
+                "npx", "milkygen", "generate", "kotlin/kotlinx-serialization",
                 "--version", version.get(),
                 "--output", file.absolutePath
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ ksp = "2.3.10"
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/saltify-core/build.gradle.kts
+++ b/saltify-core/build.gradle.kts
@@ -31,10 +31,11 @@ kotlin {
 
         commonTest.dependencies {
             implementation(kotlin("test"))
+            api(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.cio)
         }
 
         jvmTest.dependencies {
-            implementation(libs.ktor.client.cio)
             implementation(libs.logback.classic)
         }
     }

--- a/saltify-core/src/commonTest/kotlin/saltify/PluginTest.kt
+++ b/saltify-core/src/commonTest/kotlin/saltify/PluginTest.kt
@@ -1,7 +1,9 @@
 package org.ntqqrev.saltify
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.ntqqrev.milky.IncomingMessage
 import org.ntqqrev.saltify.builtin.plugin.commandHelp
 import org.ntqqrev.saltify.builtin.plugin.defaultLogging
@@ -9,11 +11,12 @@ import org.ntqqrev.saltify.dsl.SaltifyPlugin
 import org.ntqqrev.saltify.extension.*
 import org.ntqqrev.saltify.model.event.EventConnectionType
 import kotlin.test.Test
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 
 class PluginTest {
     @Test
-    fun test(): Unit = runBlocking {
+    fun test() = runTest(timeout = Duration.INFINITE) {
         val client = SaltifyApplication {
             connection {
                 baseUrl = "http://localhost:3010"
@@ -37,7 +40,7 @@ class PluginTest {
         }.start()
 
         client.connectEvent()
-        delay(60000.milliseconds)
+        withContext(Dispatchers.Default) { delay(1.hours) }
         client.disconnectEvent()
         client.close()
     }


### PR DESCRIPTION
偶尔需要在 native 环境下，检测代码是否有效。

移动后只需要在commonTest里选择变体即可快速启动示例（尽管native侧link速度缓慢）

